### PR TITLE
Configure Spring Cloud for Service Discovery

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,19 @@
     <description>product-service</description>
     <properties>
         <java.version>17</java.version>
+        <spring-cloud.version>2023.0.0</spring-cloud.version>
     </properties>
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.springframework.cloud</groupId>
+                <artifactId>spring-cloud-dependencies</artifactId>
+                <version>${spring-cloud.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
     <dependencies>
         <dependency>
             <groupId>org.springframework.boot</groupId>
@@ -35,6 +47,10 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.cloud</groupId>
+            <artifactId>spring-cloud-starter-netflix-eureka-client</artifactId>
         </dependency>
     </dependencies>
 

--- a/src/main/java/org/example/productservice/ProductServiceApplication.java
+++ b/src/main/java/org/example/productservice/ProductServiceApplication.java
@@ -2,8 +2,10 @@ package org.example.productservice;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cloud.client.discovery.EnableDiscoveryClient;
 
 @SpringBootApplication
+@EnableDiscoveryClient
 public class ProductServiceApplication {
 
   public static void main(String[] args) {

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -5,3 +5,6 @@ spring.data.mongodb.password=${MONGO_ROOT_PASSWORD}
 spring.data.mongodb.database=product
 spring.data.mongodb.port=27017
 server.port=8080
+
+# Eureka Server URL
+eureka.client.service-url.default-zone=http://localhost:8761/eureka


### PR DESCRIPTION
### Description:
This pull request introduces the following changes to the codebase:

### Changes:
- **Updated `pom.xml`:**
  - Included Spring Cloud dependencies and set the version to ${spring-cloud.version}.
  - Added Spring Cloud Eureka Client dependency to enable service registration.

- **Modified `ProductServiceApplication.java`:**
  - Annotated with `@EnableDiscoveryClient` to enable the service to register with Eureka.

- **Updated `application.properties`:**
  - Set the Eureka Server URL using `eureka.client.service-url.default-zone`.

### Purpose:
The purpose of this pull request is to enable service discovery in the Product Service by configuring Spring Cloud with Eureka. This integration enhances the microservices architecture by providing a centralized service registry.
