### PR TITLE
Updated MongoDB configurations for different profiles

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -4,7 +4,7 @@ services:
     image: mongo
     container_name: product-service
     ports:
-      - "27017:27017"
+      - "27018:27017"
     volumes:
       - data:/data
     environment:
@@ -17,7 +17,7 @@ services:
     ports:
       - "8081:8081"
     environment:
-      - ME_CONFIG_MONGODB_URL="mongodb://${MONGO_ROOT_USERNAME}:${MONGO_ROOT_PASSWORD}@mongo:27017/"
+      - ME_CONFIG_MONGODB_URL="mongodb://${MONGO_ROOT_USERNAME}:${MONGO_ROOT_PASSWORD}@mongo:27018/"
       - ME_CONFIG_MONGODB_ADMINUSERNAME=${MONGO_ROOT_USERNAME}
       - ME_CONFIG_MONGODB_ADMINPASSWORD=${MONGO_ROOT_PASSWORD}
       - ME_CONFIG_MONGODB_SERVER=mongodb

--- a/src/main/resources/application-dev.properties
+++ b/src/main/resources/application-dev.properties
@@ -1,0 +1,6 @@
+spring.data.mongodb.host=localhost
+spring.data.mongodb.authentication-database=admin
+spring.data.mongodb.username=${MONGO_ROOT_USERNAME}
+spring.data.mongodb.password=${MONGO_ROOT_PASSWORD}
+spring.data.mongodb.database=product
+spring.data.mongodb.port=27018

--- a/src/main/resources/application-local.properties
+++ b/src/main/resources/application-local.properties
@@ -1,0 +1,3 @@
+spring.data.mongodb.host=localhost
+spring.data.mongodb.database=product
+spring.data.mongodb.port=27017

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,9 +1,5 @@
-spring.data.mongodb.host=localhost
-spring.data.mongodb.authentication-database=admin
-spring.data.mongodb.username=${MONGO_ROOT_USERNAME}
-spring.data.mongodb.password=${MONGO_ROOT_PASSWORD}
-spring.data.mongodb.database=product
-spring.data.mongodb.port=27017
+spring.profiles.active=local
+
 server.port=8080
 
 # Eureka Server URL


### PR DESCRIPTION
### Description:
This pull request introduces changes to the codebase for better MongoDB configuration management, including profile-specific configurations and Docker Compose adjustments.

### Changes:
- Modified `docker-compose.yaml` to use port 27018 for the `mongo` service.
- Updated `ME_CONFIG_MONGODB_URL` in `docker-compose.yaml` for the `mongo-express` service to use port 27018.
- Added new property file `application-dev.properties` with MongoDB configurations for the 'dev' profile.
- Added new property file `application-local.properties` with MongoDB configurations for the 'local' profile.
- Removed MongoDB configurations from the main `application.properties`.
- Set `spring.profiles.active=local` in `application.properties`.

### Purpose:
The purpose of this pull request is to enhance MongoDB configuration management by providing separate configurations for different profiles ('dev' and 'local'). Additionally, the Docker Compose file has been updated to use the appropriate port (27018) for MongoDB in the 'dev' profile.
