### PR TITLE
Refactor MongoDB configuration for Product Service

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,5 @@ build/
 .vscode/
 
 .env
+
+mongo-product-service

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,29 +1,13 @@
 version: "3.8"
 services:
-  mongodb:
+  mongo:
     image: mongo
-    container_name: product-service
+    container_name: mongo-product-service
     ports:
       - "27018:27017"
     volumes:
-      - data:/data
+      - ./mongo-product-service:/data/db
     environment:
       - MONGO_INITDB_ROOT_USERNAME=${MONGO_ROOT_USERNAME}
       - MONGO_INITDB_ROOT_PASSWORD=${MONGO_ROOT_PASSWORD}
-  mongo-express:
-    image: mongo-express
-    container_name: mongo-express
-    restart: always
-    ports:
-      - "8081:8081"
-    environment:
-      - ME_CONFIG_MONGODB_URL="mongodb://${MONGO_ROOT_USERNAME}:${MONGO_ROOT_PASSWORD}@mongo:27018/"
-      - ME_CONFIG_MONGODB_ADMINUSERNAME=${MONGO_ROOT_USERNAME}
-      - ME_CONFIG_MONGODB_ADMINPASSWORD=${MONGO_ROOT_PASSWORD}
-      - ME_CONFIG_MONGODB_SERVER=mongodb
-volumes:
-  data: {}
-
-networks:
-  default:
-    name: mongodb_network
+    restart: unless-stopped

--- a/src/main/resources/application-dev.properties
+++ b/src/main/resources/application-dev.properties
@@ -1,6 +1,6 @@
 spring.data.mongodb.host=localhost
 spring.data.mongodb.authentication-database=admin
-spring.data.mongodb.username=${MONGO_ROOT_USERNAME}
-spring.data.mongodb.password=${MONGO_ROOT_PASSWORD}
+spring.data.mongodb.username=root
+spring.data.mongodb.password=root
 spring.data.mongodb.database=product
 spring.data.mongodb.port=27018


### PR DESCRIPTION
### Description:
This pull request introduces changes to the MongoDB configuration specifically for the Product Service in the `docker-compose.yaml` file and `application-dev.properties`.

### Changes:
- **Refactor MongoDB Configuration for Product Service:**
   - Renamed the `mongodb` service to `mongo` in `docker-compose.yaml`
   - Changed the container name from `product-service` to `mongo-product-service` in `docker-compose.yaml`
   - Changed the volume mapping from `data:/data` to `./mongo-product-service:/data/db` in `docker-compose.yaml`
   - Removed the `mongo-express` service from `docker-compose.yaml`
   - Removed the `networks` section from `docker-compose.yaml`
   - Added `mongo-product-service` volume to the `.gitignore` file
   - Changed the `spring.data.mongodb.username` and `spring.data.mongodb.password` properties to static values (`root` and `root`) in `application-dev.properties`
   - Added the `restart: unless-stopped` directive to the `mongo` service in `docker-compose.yaml`

### Purpose:
The purpose of this pull request is to refactor the MongoDB configuration specifically for the Product Service. The changes include renaming the MongoDB service and container for better clarity, updating the volume mapping to persist data on the host, removing the `mongo-express` service, ensuring the MongoDB container restarts automatically unless explicitly stopped, excluding the `mongo-product-service` volume from being tracked by Git, and updating the MongoDB username and password properties in `application-dev.properties` to static values for development purposes.